### PR TITLE
loop param for SoundLoader.prototype.play() now an options hash with loopStart/loopEnd.

### DIFF
--- a/lib/sound_loader.js
+++ b/lib/sound_loader.js
@@ -132,7 +132,7 @@ SoundLoader.prototype.allLoaded = function() {
 /**
  * Play a sound.
  * @param {string} name The name given to the sound during {@link SoundLoader#load}
- * @param {boolean} [loop=false] A flag denoting whether the sound should be looped. To stop a looped sound use {@link SoundLoader#stop}.
+ * @param {Object} [loop=undefined] A hash containing loopStart and loopEnd options. To stop a looped sound use {@link SoundLoader#stop}.
  */
 SoundLoader.prototype.play = function(name, loop) {
 	if (loop && this.looping[name]) {
@@ -153,6 +153,8 @@ SoundLoader.prototype.play = function(name, loop) {
 	source.connect(this.gainNode);
 	if (loop) {
 		source.loop = true;
+		source.loopStart = loop.loopStart || 0;
+		source.loopEnd = loop.loopEnd || 0;
 		this.looping[name] = source;
 	}
 	source.start(0);


### PR DESCRIPTION
To use, call for example, `soundLoader.play([soundName], { loopStart: 8.0, loopEnd: 40.0 });`. Effect of previous call style is left unchanged.
