### PR TITLE
add system to show hitboxes and collisions visually

### DIFF
--- a/lib/systems/show-hitboxes.js
+++ b/lib/systems/show-hitboxes.js
@@ -1,0 +1,14 @@
+"use strict";
+
+module.exports = function(ecs, game) {
+	game.entities.registerSearch("showHitBoxes", ["showHitBox", "size", "position", "collisions"]);
+	ecs.addEach(function drawRectangles(entity, context) {
+		context.strokeStyle = "white";
+		if (game.entities.get(entity, "collisions").length > 0) {
+			context.strokeStyle = "red";
+		}
+		var position = game.entities.get(entity, "position");
+		var size = game.entities.get(entity, "size");
+		context.strokeRect(Math.floor(position.x), Math.floor(position.y), size.width, size.height);
+	}, "showHitBoxes");
+};

--- a/lib/systems/show-hitboxes.js
+++ b/lib/systems/show-hitboxes.js
@@ -3,12 +3,14 @@
 module.exports = function(ecs, game) {
 	game.entities.registerSearch("showHitBoxes", ["showHitBox", "size", "position", "collisions"]);
 	ecs.addEach(function drawRectangles(entity, context) {
-		context.strokeStyle = "white";
-		if (game.entities.get(entity, "collisions").length > 0) {
-			context.strokeStyle = "red";
+		if (game.entities.get(entity, "showHitBoxes")) {
+			context.strokeStyle = "white";
+			if (game.entities.get(entity, "collisions").length > 0) {
+				context.strokeStyle = "red";
+			}
+			var position = game.entities.get(entity, "position");
+			var size = game.entities.get(entity, "size");
+			context.strokeRect(Math.floor(position.x), Math.floor(position.y), size.width, size.height);
 		}
-		var position = game.entities.get(entity, "position");
-		var size = game.entities.get(entity, "size");
-		context.strokeRect(Math.floor(position.x), Math.floor(position.y), size.width, size.height);
 	}, "showHitBoxes");
 };

--- a/lib/systems/show-hitboxes.js
+++ b/lib/systems/show-hitboxes.js
@@ -3,7 +3,7 @@
 module.exports = function(ecs, game) {
 	game.entities.registerSearch("showHitBoxes", ["showHitBox", "size", "position", "collisions"]);
 	ecs.addEach(function drawRectangles(entity, context) {
-		if (game.entities.get(entity, "showHitBoxes")) {
+		if (game.entities.get(entity, "showHitBox")) {
 			context.strokeStyle = "white";
 			if (game.entities.get(entity, "collisions").length > 0) {
 				context.strokeStyle = "red";


### PR DESCRIPTION
This system shows a white stroked rectangle for all entities that have "showHitBox", "size", "position", and "collisions".

If an entity has anything in its collisions array it's hitbox turns red.

Recommended use of this system is including it in your game's systems.json by default and turning it on per entity using `"showHitBox": true`
