### PR TITLE
allow user to define 'all' in scenes array in systems.json 

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -112,7 +112,7 @@ Game.prototype.makeSceneData = function(entities, sceneArgs) {
 };
 Game.prototype.installSystems = function(scene, systems, ecs, data) {
 	systems.forEach(function(system) {
-		if (system.scenes.indexOf(scene) === -1 && system.scenes[0] !== "all") {
+		if (system.scenes.indexOf(scene) === -1 && system.scenes !== "all") {
 			return;
 		}
 		var script = this.require(system.name);

--- a/lib/game.js
+++ b/lib/game.js
@@ -112,7 +112,7 @@ Game.prototype.makeSceneData = function(entities, sceneArgs) {
 };
 Game.prototype.installSystems = function(scene, systems, ecs, data) {
 	systems.forEach(function(system) {
-		if (system.scenes.indexOf(scene) === -1) {
+		if (system.scenes.indexOf(scene) === -1 && system.scenes[0] !== "all") {
 			return;
 		}
 		var script = this.require(system.name);


### PR DESCRIPTION
If scenes array has "all" as the first element, the system gets added to all scenes in the game regardless of anything else in the array. The biggest issue is this doesn't allow a scene named "all" to have a system that doesn't go on every scene.
