### PR TITLE
add applyScale system

### DIFF
--- a/lib/systems/apply-scale.js
+++ b/lib/systems/apply-scale.js
@@ -1,0 +1,27 @@
+"use strict";
+
+module.exports = function(ecs, game) { // eslint-disable-line no-unused-vars
+  game.entities.registerSearch("applyScale", ["scale", "size"]);
+  ecs.addEach(function applyScale(entity, elapsed) { // eslint-disable-line no-unused-vars
+    var percent = game.entities.get(entity, "scale");
+    if (game.entities.get(entity, "lastScale")) {
+      if (game.entities.get(entity, "lastScale") !== percent) {
+        scaleEntity(game, entity, percent);
+        game.entities.set(entity, "lastScale", percent);
+      }
+    } else {
+      var size = game.entities.get(entity, "size");
+      game.entities.set(entity, "originalSize", size);
+      scaleEntity(game, entity, percent);
+      game.entities.set(entity, "lastScale", percent);
+    }
+  }, "applyScale");
+};
+
+function scaleEntity(game, entity, percent) {
+  var originalSize = game.entities.get(entity, "originalSize");
+  game.entities.set(entity, "size", {
+    "width": originalSize.width * percent,
+    "height": originalSize.height * percent
+  });
+}

--- a/lib/systems/apply-scale.js
+++ b/lib/systems/apply-scale.js
@@ -3,25 +3,28 @@
 module.exports = function(ecs, game) { // eslint-disable-line no-unused-vars
   game.entities.registerSearch("applyScale", ["scale", "size"]);
   ecs.addEach(function applyScale(entity, elapsed) { // eslint-disable-line no-unused-vars
-    var percent = game.entities.get(entity, "scale");
-    if (game.entities.get(entity, "lastScale")) {
-      if (game.entities.get(entity, "lastScale") !== percent) {
-        scaleEntity(game, entity, percent);
-        game.entities.set(entity, "lastScale", percent);
+    var scale = game.entities.get(entity, "scale");
+    console.log(game.entities.get(entity, "scale"));
+    if (scale.last) {
+      if (scale.last !== scale.current) {
+        scaleEntity(game, entity, scale);
+        scale.last = scale.current;
       }
     } else {
       var size = game.entities.get(entity, "size");
       game.entities.set(entity, "originalSize", size);
-      scaleEntity(game, entity, percent);
-      game.entities.set(entity, "lastScale", percent);
+      scaleEntity(game, entity, scale);
+      scale.last = scale.current;
     }
   }, "applyScale");
 };
 
-function scaleEntity(game, entity, percent) {
-  var originalSize = game.entities.get(entity, "originalSize");
-  game.entities.set(entity, "size", {
-    "width": originalSize.width * percent,
-    "height": originalSize.height * percent
-  });
+function scaleEntity(game, entity, scale) {
+  if (scale.current < scale.max) {
+    var originalSize = game.entities.get(entity, "originalSize");
+    game.entities.set(entity, "size", {
+      "width": originalSize.width * scale.current,
+      "height": originalSize.height * scale.current
+    });
+  }
 }

--- a/lib/systems/apply-scale.js
+++ b/lib/systems/apply-scale.js
@@ -4,27 +4,33 @@ module.exports = function(ecs, game) { // eslint-disable-line no-unused-vars
   game.entities.registerSearch("applyScale", ["scale", "size"]);
   ecs.addEach(function applyScale(entity, elapsed) { // eslint-disable-line no-unused-vars
     var scale = game.entities.get(entity, "scale");
-    console.log(game.entities.get(entity, "scale"));
     if (scale.last) {
       if (scale.last !== scale.current) {
-        scaleEntity(game, entity, scale);
-        scale.last = scale.current;
+        scaleWithMax(game, entity, scale);
       }
     } else {
       var size = game.entities.get(entity, "size");
       game.entities.set(entity, "originalSize", size);
-      scaleEntity(game, entity, scale);
-      scale.last = scale.current;
+      scaleWithMax(game, entity, scale);
     }
   }, "applyScale");
 };
 
-function scaleEntity(game, entity, scale) {
-  if (scale.current < scale.max) {
-    var originalSize = game.entities.get(entity, "originalSize");
-    game.entities.set(entity, "size", {
-      "width": originalSize.width * scale.current,
-      "height": originalSize.height * scale.current
-    });
+function scaleWithMax(game, entity, scale) {
+  if (scale.max) {
+    if (scale.current < scale.max) {
+      scaleEntity(game, entity, scale);
+    }
+  } else {
+    scaleEntity(game, entity, scale);
   }
+}
+
+function scaleEntity(game, entity, scale) {
+  var originalSize = game.entities.get(entity, "originalSize");
+  game.entities.set(entity, "size", {
+    "width": originalSize.width * scale.current,
+    "height": originalSize.height * scale.current
+  });
+  scale.last = scale.current;
 }


### PR DESCRIPTION
Example: 
any entity with:

```
"scale": {
  "current": 0.5
}
```

will be scaled to 50% of it's original size.

The scale only happens if the scale has changed since last frame, and is the "current" scale persent is below the "max".

To set a max: 

```
"scale": {
  "current": 0.5,
  "max": 1
}
```

This system creates or changes a `"last"` property each time it successfully scales an entity, this prevents scaling every frame by comparing the `"last"` with `"current"` and only scaling if they differ.
