### PR TITLE
getMultiple, setMultiple in save-data don't fire callback inside try block

### DIFF
--- a/lib/save-data.js
+++ b/lib/save-data.js
@@ -26,18 +26,18 @@ function getMultiple(getSingleFunc, keys, callback) {
     keys = [keys];
   }
 
+  var data;
   try {
-    var data = keys.map(function(key) {
+    data = keys.map(function(key) {
       return [key, getSingleFunc(key)];
     }).reduce(function(accum, pair) {
       accum[pair[0]] = pair[1];
       return accum;
     }, {});
-
-    callback(undefined, data);
   } catch (e) {
-    callback(e);
+    return callback(e);
   }
+  callback(undefined, data);
 }
 
 function setMultiple(setSingleFunc, data, callback) {
@@ -47,10 +47,10 @@ function setMultiple(setSingleFunc, data, callback) {
         setSingleFunc(key, data[key]);
       }
     }
-    callback();
   } catch (e) {
-    callback(e);
+    return callback(e);
   }
+  callback();
 }
 
 var cookieSaveData = {


### PR DESCRIPTION
Previously, the `getMultiple` and `setMultiple` functions in the `save-data` module would synchronously fire successful callbacks at the end of a try block. Innocuous at first, this causes debugging headaches if an error occurs later on in the callback (as it did for me) - the catch block from way back when handles the exception, then our callback gets called _a second time_ with an error, and it's not at all clear from the stack trace that the error actually occurred _after_ the callback's error handler, which ends up finally printing our issue to the console (even though we passed over it the first time when there was no error).

A cool but unnecessary solution would be to fire the callback asynchronously with `setTimeout`. Instead, I just fire the success callback outside of the `try` / `catch` blocks.
